### PR TITLE
Add id to constructor as it is mandatory in the spec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,6 @@ export class GattMock extends EventTarget implements BluetoothRemoteGATTServer {
 export class DeviceMock extends EventTarget implements BluetoothDevice {
     public watchingAdvertisements = false;
     public gatt: GattMock;
-    public id = "";
 
     public ongattserverdisconnected: (E: Event) => void;
     public oncharacteristicvaluechanged: (E: Event) => void;
@@ -149,9 +148,10 @@ export class DeviceMock extends EventTarget implements BluetoothDevice {
 
     private serviceMocks: { [service: string]: PrimaryServiceMock } = {};
 
-    constructor(public name: string, private services: BluetoothServiceUUID[]) {
+    constructor(public name: string, private services: BluetoothServiceUUID[], public id: string) {
         super();
         this.gatt = new GattMock(this);
+        this.id = id;
     }
 
     public hasService(service: BluetoothServiceUUID) {


### PR DESCRIPTION
According to the specification [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/BluetoothDevice#Properties), the property id is a mandatory field.

This PR adds id to the constructor. Unfortunately this leads to a breaking change for users of this library.