### PR TITLE
Change size of characteristic data frame's buffer to 1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export class CharacteristicMock extends EventTarget implements BluetoothRemoteGA
 
     constructor(public service: PrimaryServiceMock, public uuid: string) {
         super();
-        this.value = new DataView(new Uint8Array(0).buffer);
+        this.value = new DataView(new Uint8Array(1).buffer);
     }
 
     public startNotifications(): Promise<BluetoothRemoteGATTCharacteristic> {


### PR DESCRIPTION
I was having trouble testing with readValue(), as my readers also parse the data. By changing the value of the buffer length, this problem is mitigated.