### PR TITLE
Added new writeValue methods due to new Web Bluetooth standard

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,14 @@ export class CharacteristicMock extends EventTarget implements BluetoothRemoteGA
         return Promise.resolve();
     }
 
+    public writeValueWithoutResponse() {
+        return Promise.resolve();
+    }
+
+    public writeValueWithResponse() {
+        return Promise.resolve();
+    }
+
     public getDescriptor() {
         return Promise.reject(new Error("Not implemented"));
     }


### PR DESCRIPTION
This one is needed for the proper testing of the cases when `writeValueWithoutResponse` and `writeValueWithResponse` are used to send data via Bluetooth